### PR TITLE
Allow Kerberos Auth

### DIFF
--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -302,6 +302,7 @@ async function initializeAfterAppReady() {
     const defaultSession = session.defaultSession;
 
     if (process.platform !== 'darwin') {
+        defaultSession.allowNTLMCredentialsForDomains('*');
         defaultSession.on('spellcheck-dictionary-download-failure', (event, lang) => {
             if (Config.spellCheckerURL) {
                 log.error(`There was an error while trying to load the dictionary definitions for ${lang} from fully the specified url. Please review you have access to the needed files. Url used was ${Config.spellCheckerURL}`);


### PR DESCRIPTION
Add "allowNTLMCredentialsForDomains" to allow Kerberos Auth with Keycloak